### PR TITLE
Update Binder to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
       <dependency>
         <groupId>com.solace.spring.cloud</groupId>
         <artifactId>spring-cloud-stream-binder-solace</artifactId>
-        <version>0.1.0</version>
+        <version>1.0.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Solace Spring Cloud Stream Binder dependency updated to 1.0.0.