### PR TITLE
Update Spring Cloud Streams to 2.1.x (Fishtown) and Solace Binder to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.0.0.RELEASE</version>
+    <version>2.1.2.RELEASE</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 
@@ -53,7 +53,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <spring-cloud-stream.version>2.0.0.RELEASE</spring-cloud-stream.version>
+    <spring-cloud-stream.version>2.1.0.RELEASE</spring-cloud-stream.version>
   </properties>
 
   <repositories>
@@ -83,7 +83,7 @@
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-stream-dependencies</artifactId>
-        <version>Elmhurst.RELEASE</version>
+        <version>Fishtown.RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -91,7 +91,7 @@
       <dependency>
         <groupId>com.solace.spring.cloud</groupId>
         <artifactId>spring-cloud-stream-binder-solace</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
* Solace Spring Cloud Stream Binder updated to 1.1.0
* Spring Cloud Streams updated to 2.1.x (Fishtown)