### PR TITLE
SOL-332222: Upgrade solace-spring-cloud BOM to 1.0.1

### DIFF
--- a/dynamic-destination-source/pom.xml
+++ b/dynamic-destination-source/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<spring-cloud.version>Hoxton.SR1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>1.0.0</solace-spring-cloud-bom.version>
+		<solace-spring-cloud-bom.version>1.0.1</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/jdbc-sink/pom.xml
+++ b/jdbc-sink/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<spring-cloud.version>Hoxton.SR1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>1.0.0</solace-spring-cloud-bom.version>
+		<solace-spring-cloud-bom.version>1.0.1</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
     <spring-boot.version>2.2.4.RELEASE</spring-boot.version>
     <spring-cloud.version>Hoxton.SR1</spring-cloud.version>
-    <solace-spring-cloud-bom.version>1.0.0</solace-spring-cloud-bom.version>
+    <solace-spring-cloud-bom.version>1.0.1</solace-spring-cloud-bom.version>
   </properties>
 
   <dependencyManagement>

--- a/reactive-processor/pom.xml
+++ b/reactive-processor/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <spring-cloud.version>Hoxton.SR1</spring-cloud.version>
-        <solace-spring-cloud-bom.version>1.0.0</solace-spring-cloud-bom.version>
+        <solace-spring-cloud-bom.version>1.0.1</solace-spring-cloud-bom.version>
     </properties>
 
     <dependencyManagement>

--- a/streamlistener-basic/pom.xml
+++ b/streamlistener-basic/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<spring-cloud.version>Hoxton.SR1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>1.0.0</solace-spring-cloud-bom.version>
+		<solace-spring-cloud-bom.version>1.0.1</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
Upgrade `solace-spring-cloud-bom` to 1.0.1 to fix an issue regarding keeping the JVM alive when we have consumers running.