### PR TITLE
Remove Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: java
-dist: trusty
-sudo: false
-script: mvn clean package
-jdk: 
-  - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/SolaceLabs/solace-samples-spring-cloud-stream.svg?branch=master)](https://travis-ci.org/SolaceLabs/solace-samples-spring-cloud-stream)
-
 # Spring Cloud Streams - Getting Started Examples
 
 These samples have been hand-picked from the [Spring Cloud Stream samples](https://github.com/spring-cloud/spring-cloud-stream-samples) project in order to demonstrate the functionality of the [Spring Cloud Stream Binder for Solace PubSub+](https://github.com/SolaceProducts/spring-cloud-stream-binder-solace). Aside from their configuration, these applications have remained mostly untouched.


### PR DESCRIPTION
Remove Travis CI. Not going to bother with migrating this to Github Actions since this repo is no longer unmaintained.